### PR TITLE
Update TargetFrameworks to net8.0 for Android and iOS (JailbreakDetector)

### DIFF
--- a/src/banditoth.MAUI.JailbreakDetector/banditoth.MAUI.JailbreakDetector.csproj
+++ b/src/banditoth.MAUI.JailbreakDetector/banditoth.MAUI.JailbreakDetector.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. -->
 		<!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>-->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->


### PR DESCRIPTION
Updated the TargetFrameworks in the project file from net7.0-android;net7.0-ios to net8.0-android;net8.0-ios to leverage the latest features and improvements in .NET 8. This chang addresses compatibility issues with net8.0.