### PR TITLE
Update banditoth.MAUI.PreferencesExtension.csproj

### DIFF
--- a/src/banditoth.MAUI.PreferencesExtension/banditoth.MAUI.PreferencesExtension.csproj
+++ b/src/banditoth.MAUI.PreferencesExtension/banditoth.MAUI.PreferencesExtension.csproj
@@ -35,6 +35,5 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.70" />
-	  <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.70" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This change removes the unnecessary dependency on Microsoft.Maui.Controls.Compatibility from the project. Microsoft.Maui.Controls.Compatibility is not used in the PreferencesExtension, and the reason for removing it as a transitive package is that it has been deprecated in .Net 9.